### PR TITLE
Fix IsConstExpr(bool) evaluated to False.

### DIFF
--- a/eudplib/core/allocator/constexpr.py
+++ b/eudplib/core/allocator/constexpr.py
@@ -160,6 +160,6 @@ def Evaluate(x):
 def IsConstExpr(x):
     x = ut.unProxy(x)
     return (
-        type(x) in (int, RlocInt_C) or
+        isinstance(x, (int, RlocInt_C)) or
         hasattr(x, 'Evaluate')
     )


### PR DESCRIPTION
In c5cb0c169e947606175babc637621f48ced993c6, `isinstance` is replaced to `type`.
Since `type(bool) in (int, RlocInt_C)` is `False`, expressions like `EUDReturn(True)` issue error as follow.

```
  File "test.eps", line 11, in f_test
    return True;
  File "eudplib\core\eudfunc\eudfuncn.py", line 188, in EUDReturn
  File "eudplib\core\eudfunc\eudfuncn.py", line 149, in _AddReturn
  File "eudplib\core\variable\eudv.py", line 501, in SetVariables
  File "eudplib\core\variable\eudv.py", line 489, in SeqCompute
  File "eudplib\core\variable\eudv.py", line 451, in FlushPairs
  File "eudplib\core\variable\eudv.py", line 394, in _SeqComputeSub
  File "eudplib\core\rawtrigger\rawtriggerdef.py", line 108, in __init__
  File "eudplib\core\rawtrigger\action.py", line 96, in CheckArgs
  File "eudplib\utils\eperror.py", line 33, in ep_assert
eudplib.utils.eperror.EPError: Invalid player2 "True" in trigger index 0
```